### PR TITLE
Added Textarea selector for editorfields

### DIFF
--- a/src/grid/js/grid.inlineEditing.js
+++ b/src/grid/js/grid.inlineEditing.js
@@ -279,7 +279,7 @@ gj.grid.plugins.inlineEditing.private = {
         if ($cell.attr('data-mode') !== 'edit' && column.editor) {
             if (data.inlineEditing.mode !== 'command') {
                 $('div[data-role="edit"]:visible').parent('td').each(function () {
-                    $(this).find('input, select').triggerHandler('blur');
+                    $(this).find('input, select, textarea').triggerHandler('blur');
                 });
             }
             $displayContainer = $cell.find('div[data-role="display"]').hide();
@@ -289,7 +289,7 @@ gj.grid.plugins.inlineEditing.private = {
                 $cell.append($editorContainer);
             }
             value = record[column.field] || $displayContainer.html();
-            $editorField = $editorContainer.find('input, select').first();
+            $editorField = $editorContainer.find('input, select, textarea').first();
             if ($editorField.length) {
                 $editorField.val(value);
             } else {
@@ -298,7 +298,7 @@ gj.grid.plugins.inlineEditing.private = {
                 } else if (typeof (column.editor) === 'boolean') {
                     $editorContainer.append('<input type="text" value="' + value + '" class="gj-width-full"/>');
                 }
-                $editorField = $editorContainer.find('input, select').first();
+                $editorField = $editorContainer.find('input, select, textarea').first();
                 if (data.inlineEditing.mode !== 'command') {
                     $editorField.on('blur', function (e) {
                         gj.grid.plugins.inlineEditing.private.displayMode($grid, $cell, column);
@@ -339,7 +339,7 @@ gj.grid.plugins.inlineEditing.private = {
         if ($cell.attr('data-mode') === 'edit') {
             $editorContainer = $cell.find('div[data-role="edit"]');
             $displayContainer = $cell.find('div[data-role="display"]');
-            newValue = $editorContainer.find('input, select').first().val();
+            newValue = $editorContainer.find('input, select, textarea').first().val();
             position = $cell.parent().data('position');
             record = $grid.get(position);
             oldValue = record[column.field];


### PR DESCRIPTION
Sometimes a simple input field is too small for editing large text. With this commit textareas can be used as editorfields.