### PR TITLE
Include method get checked items

### DIFF
--- a/src/tree/js/tree.base.methods.js
+++ b/src/tree/js/tree.base.methods.js
@@ -453,6 +453,7 @@ gj.tree.methods = {
         return $tree;
     },
 	
+	
 	getCheckedItems: function () {
             var result = [],
                 checkboxes = this.find('li [data-role="node"] [data-role="checkbox"] input[type="checkbox"]');

--- a/src/tree/js/tree.base.methods.js
+++ b/src/tree/js/tree.base.methods.js
@@ -451,5 +451,17 @@ gj.tree.methods = {
             $tree.removeClass().empty();
         }
         return $tree;
-    }
+    },
+	
+	getCheckedItems: function () {
+            var result = [],
+                checkboxes = this.find('li [data-role="node"] [data-role="checkbox"] input[type="checkbox"]');
+            $.each(checkboxes, function () {
+                var checkbox = $(this);
+                if (checkbox.checkbox('state') === 'checked') {
+                    result.push(checkbox.closest('li').data('id'));
+                }
+            });
+            return result;
+        }
 }


### PR DESCRIPTION
This pull request includes a new method that return all checked items


This method was created to perform the search of the items that are checked, neglecting the main item.

Senary:
I am mounting a treeview to select the menus that will be displayed for each registered profile, if a "submenu" item is selected the main menu will automatically be displayed.

For this reason I have identified the need to create this feature to fetch the selected items.