### PR TITLE
New event added for tree.checkboxes, to fix issue #403

### DIFF
--- a/src/tree/js/tree.checkboxes.js
+++ b/src/tree/js/tree.checkboxes.js
@@ -131,6 +131,7 @@ gj.tree.plugins.checkboxes = {
                     gj.tree.plugins.checkboxes.private.updateChildrenState($node, state);
                     gj.tree.plugins.checkboxes.private.updateParentState($node, state);
                 }
+                gj.tree.plugins.checkboxes.events.changed($tree, $node, record, $checkbox.state());
             });
             $expander.after($wrapper);
         },
@@ -334,6 +335,25 @@ gj.tree.plugins.checkboxes = {
          */
         checkboxChange: function ($tree, $node, record, state) {
             return $tree.triggerHandler('checkboxChange', [$node, record, state]);
+        },
+        /**
+         * Event fires when the checkbox state is changed, but only once per click.
+         * @event changed
+         * @param {object} e - event data
+         * @param {object} $node - the node object as jQuery element
+         * @param {object} record - the record data
+         * @param {string} state - the new state of the checkbox
+         * @example Event.Sample <!-- checkbox, tree -->
+         * <div id="tree" data-source="/Locations/Get" data-checkboxes="true"></div>
+         * <script>
+         *     var tree = $('#tree').tree();
+         *     tree.on('changed', function (e, $node, record, state) {
+         *         alert('This is only triggered once and the new state of record ' + record.text + ' is ' + state);
+         *     });
+         * </script>
+         */
+        changed: function($tree, $node, record, state){
+            return $tree.triggerHandler('changed', [$node, record, state]);
         }
     },
 


### PR DESCRIPTION
Hi, 

This is for resolving the problem raised by clicking the tree view checkboxes which mentioned in issue #403. I intended to click a tree node then  execute a search action, but failed to find the proper event. By using 'checkboxChange', the search action would be executed multi times. So I hope this pull request can be allowed.

Really like this project and hope it would become better and better.