### PR TITLE
Japanese support

### DIFF
--- a/src/core/js/messages/messages.ja-jp.js
+++ b/src/core/js/messages/messages.ja-jp.js
@@ -48,5 +48,59 @@ gj.core.messages['ja-jp'] = {
     am: '午前',
     pm: '午後',
     ok: 'OK',
-    cancel: 'キャンセル'
+    cancel: 'キャンセル',
+gj.dialog.messages['ja-jp'] = {
+    Close: '閉じる',
+    DefaultTitle: 'ダイアログ'
+};
+gj.grid.messages['ja-jp'] = {
+    First: '最初',
+    Previous: '前',
+    Next: '次',
+    Last: '最後',
+    Page: 'ページ',
+    FirstPageTooltip: '最初のページ',
+    PreviousPageTooltip: '前のページ',
+    NextPageTooltip: '次のページ',
+    LastPageTooltip: '最後のページ',
+    Refresh: 'リフレッシュ',
+    Of: 'の',
+    DisplayingRecords: '結果',
+    RowsPerPage: 'ページあたり行数:',
+    Edit: '編集',
+    Delete: '削除',
+    Update: '更新',
+    Cancel: 'キャンセル',
+    NoRecordsFound: 'レコードが見つかりません',
+    Loading: '読み込み中...'
+};
+gj.editor.messages['ja-jp'] = {
+    bold: '太字',
+    italic: '斜体',
+    strikethrough: '打消し線',
+    underline: '下線',
+    listBulleted: '箇条書き',
+    listNumbered: '番号付き箇条書き',
+    indentDecrease: 'インデントを減らす',
+    indentIncrease: 'インデントを増やす',
+    alignLeft: '左揃え',
+    alignCenter: '中央揃え',
+    alignRight: '右揃え',
+    alignJustify: '両端揃え',
+    undo: '元に戻す',
+    redo: 'やり直し'
+};
+gj.core.messages['ja-jp'] = {
+    monthNames: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+    monthShortNames: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+    weekDaysMin: ['日', '月', '火', '水', '木', '金', '土'],
+    weekDaysShort: ['日', '月', '火', '水', '木', '金', '土'],
+    weekDays: ['日曜', '月曜', '火曜', '水曜', '木曜', '金曜', '土曜'],
+    am: '午前',
+    pm: '午後',
+    ok: 'OK',
+    cancel: 'キャンセル',
+    titleFun: function(year, month) {
+        return year + '年' + month;
+    }
 };

--- a/src/core/js/messages/messages.ja-jp.js
+++ b/src/core/js/messages/messages.ja-jp.js
@@ -1,0 +1,52 @@
+gj.dialog.messages['ja-jp'] = {
+    Close: '閉じる',
+    DefaultTitle: 'ダイアログ'
+};
+gj.grid.messages['ja-jp'] = {
+    First: '最初',
+    Previous: '前',
+    Next: '次',
+    Last: '最後',
+    Page: 'ページ',
+    FirstPageTooltip: '最初のページ',
+    PreviousPageTooltip: '前のページ',
+    NextPageTooltip: '次のページ',
+    LastPageTooltip: '最後のページ',
+    Refresh: 'リフレッシュ',
+    Of: 'の',
+    DisplayingRecords: '結果',
+    RowsPerPage: 'ページあたり行数:',
+    Edit: '編集',
+    Delete: '削除',
+    Update: '更新',
+    Cancel: 'キャンセル',
+    NoRecordsFound: 'レコードが見つかりません',
+    Loading: '読み込み中...'
+};
+gj.editor.messages['ja-jp'] = {
+    bold: '太字',
+    italic: '斜体',
+    strikethrough: '打消し線',
+    underline: '下線',
+    listBulleted: '箇条書き',
+    listNumbered: '番号付き箇条書き',
+    indentDecrease: 'インデントを減らす',
+    indentIncrease: 'インデントを増やす',
+    alignLeft: '左揃え',
+    alignCenter: '中央揃え',
+    alignRight: '右揃え',
+    alignJustify: '両端揃え',
+    undo: '元に戻す',
+    redo: 'やり直し'
+};
+gj.core.messages['ja-jp'] = {
+    monthNames: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+    monthShortNames: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+    weekDaysMin: ['日', '月', '火', '水', '木', '金', '土'],
+    weekDaysShort: ['日', '月', '火', '水', '木', '金', '土'],
+    weekDays: ['日曜', '月曜', '火曜', '水曜', '木曜', '金曜', '土曜'],
+    am: '午前',
+    pm: '午後',
+    ok: 'OK',
+    cancel: 'キャンセル'
+};

--- a/src/datepicker/js/datepicker.base.js
+++ b/src/datepicker/js/datepicker.base.js
@@ -811,8 +811,12 @@ gj.datepicker.methods = {
         year = parseInt($calendar.attr('year'), 10);
 
         $calendar.attr('type', 'month');
-        $calendar.find('div[role="period"]').text(gj.core.messages[data.locale].monthNames[month] + ' ' + year);
-
+        if (gj.core.messages[data.locale].titleFun) {
+            $calendar.find('div[role="period"]').text(gj.core.messages[data.locale].titleFun(year, gj.core.messages[dat\
+a.locale].monthNames[month]));
+        } else {
+            $calendar.find('div[role="period"]').text(gj.core.messages[data.locale].monthNames[month] + ' ' + year);
+        }
         daysInMonth = new Array(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31);
         if (year % 4 == 0 && year != 1900) {
             daysInMonth[1] = 29;


### PR DESCRIPTION
Thank you for your effort,
I like GIJGO's simple way to use very much.
As Japanese developer, I'd like to add Japanese language support and some behavior into GIJGO.
 - messages.ja-jp.js for Japanese translation
 - datepikcer.base.js for support Japanese way to naming convention of the title string as year month order.

