### PR TITLE
Avoid using inline styles

### DIFF
--- a/src/timepicker/js/timepicker.base.js
+++ b/src/timepicker/js/timepicker.base.js
@@ -524,33 +524,33 @@ gj.timepicker.methods = {
         $body.empty();
         $dial = $('<div role="dial"></div>');
 
-        $dial.append('<div role="arrow" style="transform: rotate(-90deg); display: none;"><div class="arrow-begin"></div><div class="arrow-end"></div></div>');
+        $dial.append($('<div role="arrow">').css('transform', 'rotate(-90deg)').css('display', 'none').append('<div class="arrow-begin"></div><div class="arrow-end"></div>'));
 
-        $dial.append('<span role="hour" style="transform: translate(54px, -93.5307px);">1</span>');
-        $dial.append('<span role="hour" style="transform: translate(93.5307px, -54px);">2</span>');
-        $dial.append('<span role="hour" style="transform: translate(108px, 0px);">3</span>');
-        $dial.append('<span role="hour" style="transform: translate(93.5307px, 54px);">4</span>');
-        $dial.append('<span role="hour" style="transform: translate(54px, 93.5307px);">5</span>');
-        $dial.append('<span role="hour" style="transform: translate(6.61309e-15px, 108px);">6</span>');
-        $dial.append('<span role="hour" style="transform: translate(-54px, 93.5307px);">7</span>');
-        $dial.append('<span role="hour" style="transform: translate(-93.5307px, 54px);">8</span>');
-        $dial.append('<span role="hour" style="transform: translate(-108px, 1.32262e-14px);">9</span>');
-        $dial.append('<span role="hour" style="transform: translate(-93.5307px, -54px);">10</span>');
-        $dial.append('<span role="hour" style="transform: translate(-54px, -93.5307px);">11</span>');
-        $dial.append('<span role="hour" style="transform: translate(-1.98393e-14px, -108px);">12</span>');
+        $dial.append($('<span role="hour">1</span>').css('transform', 'translate(54px, -93.5307px)'));
+        $dial.append($('<span role="hour">2</span>').css('transform', 'translate(93.5307px, -54px)'));
+        $dial.append($('<span role="hour">3</span>').css('transform', 'translate(108px, 0px)'));
+        $dial.append($('<span role="hour">4</span>').css('transform', 'translate(93.5307px, 54px)'));
+        $dial.append($('<span role="hour">5</span>').css('transform', 'translate(54px, 93.5307px)'));
+        $dial.append($('<span role="hour">6</span>').css('transform', 'translate(6.61309e-15px, 108px)'));
+        $dial.append($('<span role="hour">7</span>').css('transform', 'translate(-54px, 93.5307px)'));
+        $dial.append($('<span role="hour">8</span>').css('transform', 'translate(-93.5307px, 54px)'));
+        $dial.append($('<span role="hour">9</span>').css('transform', 'translate(-108px, 1.32262e-14px)'));
+        $dial.append($('<span role="hour">10</span>').css('transform', 'translate(-93.5307px, -54px)'));
+        $dial.append($('<span role="hour">11</span>').css('transform', 'translate(-54px, -93.5307px)'));
+        $dial.append($('<span role="hour">12</span>').css('transform', 'translate(-1.98393e-14px, -108px)'));
         if (data.mode === '24hr') {
-            $dial.append('<span role="hour" style="transform: translate(38px, -65.8179px);">13</span>');
-            $dial.append('<span role="hour" style="transform: translate(65.8179px, -38px);">14</span>');
-            $dial.append('<span role="hour" style="transform: translate(76px, 0px);">15</span>');
-            $dial.append('<span role="hour" style="transform: translate(65.8179px, 38px);">16</span>');
-            $dial.append('<span role="hour" style="transform: translate(38px, 65.8179px);">17</span>');
-            $dial.append('<span role="hour" style="transform: translate(4.65366e-15px, 76px);">18</span>');
-            $dial.append('<span role="hour" style="transform: translate(-38px, 65.8179px);">19</span>');
-            $dial.append('<span role="hour" style="transform: translate(-65.8179px, 38px);">20</span>');
-            $dial.append('<span role="hour" style="transform: translate(-76px, 9.30732e-15px);">21</span>');
-            $dial.append('<span role="hour" style="transform: translate(-65.8179px, -38px);">22</span>');
-            $dial.append('<span role="hour" style="transform: translate(-38px, -65.8179px);">23</span>');
-            $dial.append('<span role="hour" style="transform: translate(-1.3961e-14px, -76px);">00</span>');
+            $dial.append($('<span role="hour">13</span>').css('transform', 'translate(38px, -65.8179px)'));
+            $dial.append($('<span role="hour">14</span>').css('transform', 'translate(65.8179px, -38px)'));
+            $dial.append($('<span role="hour">15</span>').css('transform', 'translate(76px, 0px)'));
+            $dial.append($('<span role="hour">16</span>').css('transform', 'translate(65.8179px, 38px)'));
+            $dial.append($('<span role="hour">17</span>').css('transform', 'translate(38px, 65.8179px)'));
+            $dial.append($('<span role="hour">18</span>').css('transform', 'translate(4.65366e-15px, 76px)'));
+            $dial.append($('<span role="hour">19</span>').css('transform', 'translate(-38px, 65.8179px)'));
+            $dial.append($('<span role="hour">20</span>').css('transform', 'translate(-65.8179px, 38px)'));
+            $dial.append($('<span role="hour">21</span>').css('transform', 'translate(-76px, 9.30732e-15px)'));
+            $dial.append($('<span role="hour">22</span>').css('transform', 'translate(-65.8179px, -38px)'));
+            $dial.append($('<span role="hour">23</span>').css('transform', 'translate(-38px, -65.8179px)'));
+            $dial.append($('<span role="hour">00</span>').css('transform', 'translate(-1.3961e-14px, -76px)'));
         }
         $body.append($dial);
 
@@ -569,20 +569,20 @@ gj.timepicker.methods = {
         $body.empty();
         $dial = $('<div role="dial"></div>');
 
-        $dial.append('<div role="arrow" style="transform: rotate(-90deg); display: none;"><div class="arrow-begin"></div><div class="arrow-end"></div></div>');
+        $dial.append($('<div role="arrow" style="">').css('transform', 'rotate(-90deg)').css('display', 'none').append('<div class="arrow-begin"></div><div class="arrow-end"></div>'));
 
-        $dial.append('<span role="hour" style="transform: translate(54px, -93.5307px);">5</span>');
-        $dial.append('<span role="hour" style="transform: translate(93.5307px, -54px);">10</span>');
-        $dial.append('<span role="hour" style="transform: translate(108px, 0px);">15</span>');
-        $dial.append('<span role="hour" style="transform: translate(93.5307px, 54px);">20</span>');
-        $dial.append('<span role="hour" style="transform: translate(54px, 93.5307px);">25</span>');
-        $dial.append('<span role="hour" style="transform: translate(6.61309e-15px, 108px);">30</span>');
-        $dial.append('<span role="hour" style="transform: translate(-54px, 93.5307px);">35</span>');
-        $dial.append('<span role="hour" style="transform: translate(-93.5307px, 54px);">40</span>');
-        $dial.append('<span role="hour" style="transform: translate(-108px, 1.32262e-14px);">45</span>');
-        $dial.append('<span role="hour" style="transform: translate(-93.5307px, -54px);">50</span>');
-        $dial.append('<span role="hour" style="transform: translate(-54px, -93.5307px);">55</span>');
-        $dial.append('<span role="hour" style="transform: translate(-1.98393e-14px, -108px);">00</span>');
+        $dial.append($('<span role="hour">5</span>').css('transform', 'translate(54px, -93.5307px)'));
+        $dial.append($('<span role="hour">10</span>').css('transform', 'translate(93.5307px, -54px)'));
+        $dial.append($('<span role="hour">15</span>').css('transform', 'translate(108px, 0px)'));
+        $dial.append($('<span role="hour">20</span>').css('transform', 'translate(93.5307px, 54px)'));
+        $dial.append($('<span role="hour">25</span>').css('transform', 'translate(54px, 93.5307px)'));
+        $dial.append($('<span role="hour">30</span>').css('transform', 'translate(6.61309e-15px, 108px)'));
+        $dial.append($('<span role="hour">35</span>').css('transform', 'translate(-54px, 93.5307px)'));
+        $dial.append($('<span role="hour">40</span>').css('transform', 'translate(-93.5307px, 54px)'));
+        $dial.append($('<span role="hour">45</span>').css('transform', 'translate(-108px, 1.32262e-14px)'));
+        $dial.append($('<span role="hour">50</span>').css('transform', 'translate(-93.5307px, -54px)'));
+        $dial.append($('<span role="hour">55</span>').css('transform', 'translate(-54px, -93.5307px)'));
+        $dial.append($('<span role="hour">00</span>').css('transform', 'translate(-1.98393e-14px, -108px)'));
         $body.append($dial);
 
         $clock.find('[role="header"] [role="hour"]').removeClass('selected');

--- a/src/tree/js/tree.base.methods.js
+++ b/src/tree/js/tree.base.methods.js
@@ -84,7 +84,7 @@ gj.tree.methods = {
             disabled = typeof (nodeData[data.disabledField]) !== 'undefined' && nodeData[data.disabledField].toString().toLowerCase() === 'true';
 
         if (data.indentation) {
-            $wrapper.append('<span data-role="spacer" style="width: ' + (data.indentation * (level - 1)) + 'px;"></span>');
+            $wrapper.append($('<span data-role="spacer">').css('width', (data.indentation * (level - 1)) + 'px'));
         }
 
         if (disabled) {


### PR DESCRIPTION
Hello,
Thank you for this library!

I am working on a website that has a CSP (Content Security Policy) that does not allow using inline styles. This breaks Gijgo Time Picker and Tree View (as they both create elements with style="..." attributes).

Attached changes switch to using jQuery's css() method to set these styles.

Here's a sample CSP that shows the problem:
`<meta http-equiv="Content-Security-Policy" content="default-src 'self' https:">`

(BTW, there seems to be a problem in current master branch - when I open DateTimePicker which already has date/time selected, browser freezes)

