### PR TITLE
Misstype variable name

### DIFF
--- a/src/editor/js/editor.base.js
+++ b/src/editor/js/editor.base.js
@@ -221,7 +221,7 @@ gj.editor.methods = {
         }
         $body.attr('contenteditable', true);
         $body.on('keydown', function (e) {
-            var key = event.keyCode || event.charCode;
+            var key = e.keyCode || e.charCode;
             if (gj.editor.events.changing($editor) === false && key !== 8 && key !== 46) {
                 e.preventDefault();
             }


### PR DESCRIPTION
Variable was defined as "e" and its being used as "event"