### PR TITLE
Added page scroll offsets to draggable

### DIFF
--- a/src/draggable/js/draggable.base.js
+++ b/src/draggable/js/draggable.base.js
@@ -111,8 +111,8 @@ gj.draggable.methods = {
     createDownHandle: function (widget, dragEl, data) {
         return function (e) {
             var position = gj.core.position(dragEl);
-            dragEl.style.top = position.top + 'px';
-            dragEl.style.left = position.left + 'px';
+	    dragEl.style.top = (position.top + window.pageYOffset) + 'px';
+            dragEl.style.left = (position.left + window.pageXOffset) + 'px';
             dragEl.style.position = 'fixed';
 
             dragEl.setAttribute('draggable-dragging', true);
@@ -162,8 +162,8 @@ gj.draggable.methods = {
     move: function (dragEl, data, offsetX, offsetY, mouseX, mouseY) {
         var contPosition, maxTop, maxLeft,
             position = gj.core.position(dragEl),
-            newTop = position.top + offsetY,
-            newLeft = position.left + offsetX;
+            newTop = position.top + offsetY + window.pageYOffset,
+            newLeft = position.left + offsetX + window.pageXOffset;
 
         if (data.containment) {
             contPosition = gj.core.position(data.containment);


### PR DESCRIPTION
Added `window.pageYOffset` and `window.pageXOffset` to mouse positions so that the draggable object works reliably when the page got scrolled down.

Effects can be seen by using the draggable example `Draggable.Base.drag.sample.html` and bunch of status lines have been added to the page. Try scrolling down and move the object. It just flys offscreen without this fix.