### PR TITLE
Patch to fix AM/PM problems

### DIFF
--- a/src/core/js/core.js
+++ b/src/core/js/core.js
@@ -420,7 +420,7 @@ gj.core = {
      * </script>
      */
     parseDate: function (value, format, locale) {
-        var i, year = 0, month = 0, date = 1, hour = 0, minute = 0, dateParts, formatParts, result;
+        var i, year = 0, month = 0, date = 1, hour = 0, minute = 0, mode = null, dateParts, formatParts, result;
 
         if (value && typeof value === 'string') {
             if (/^\d+$/.test(value)) {
@@ -454,7 +454,17 @@ gj.core = {
                     } else if (['M', 'MM'].indexOf(formatParts[i]) > -1) {
                         minute = parseInt(dateParts[i], 10);
                     }
+					else if (['tt', 'TT'].indexOf(formatParts[i]) > -1) {
+                        mode = dateParts[i];
+                    }
                 }
+
+				if (hour == 12 && (mode === "am" || mode === "AM")) {
+					hour = 0;
+				}
+				if (hour < 12 && (mode === "pm" || mode === "PM")) {
+					hour += 12;
+				}
                 result = new Date(year, month, date, hour, minute);
             }
         } else if (typeof value === 'number') {
@@ -537,13 +547,15 @@ gj.core = {
                 case 'HH':
                     result += gj.core.pad(date.getHours()) + separator;
                     break;
-                case 'h':
-                    tmp = date.getHours() > 12 ? date.getHours() % 12 : date.getHours();
+                case 'h':					
+					tmp = date.getHours() > 12 ? date.getHours() % 12 : date.getHours();
+					tmp = tmp == 0 ? 12 : tmp;
                     result += tmp + separator;
                     break;
                 case 'hh':
                     tmp = date.getHours() > 12 ? date.getHours() % 12 : date.getHours();
-                    result += gj.core.pad(tmp) + separator;
+					tmp = tmp == 0 ? 12 : tmp;
+					result += gj.core.pad(tmp) + separator;
                     break;
                 case 'tt':
                     result += (date.getHours() >= 12 ? 'pm' : 'am') + separator;

--- a/src/timepicker/js/timepicker.base.js
+++ b/src/timepicker/js/timepicker.base.js
@@ -440,11 +440,15 @@ gj.timepicker.methods = {
         return parseInt(clock.getAttribute('minute'), 10) || 0;
     },
 
+    getMode: function (clock) {
+        return clock.getAttribute('mode')
+    },
+
     setTime: function (picker, clock) {
         return function () {
             var hour = gj.timepicker.methods.getHour(clock),
                 minute = gj.timepicker.methods.getMinute(clock),
-                mode = clock.getAttribute('mode'),
+                mode = gj.timepicker.methods.getMode(clock),
                 date = new Date(0, 0, 0, (hour === 12 && mode === 'am' ? 0 : hour), minute),
                 data = gijgoStorage.get(picker.element, 'gijgo'),
                 value = gj.core.formatDate(date, data.format, data.locale);
@@ -507,11 +511,12 @@ gj.timepicker.methods = {
     },
 
     update: function (picker, clock, data) {
-        var hour, minute, arrow, type, visualHour, header, numbers, i, number;
+        var hour, minute, mode, arrow, type, visualHour, header, numbers, i, number;
 
         // update the arrow
         hour = gj.timepicker.methods.getHour(clock);
         minute = gj.timepicker.methods.getMinute(clock);
+        mode = gj.timepicker.methods.getMode(clock);
         arrow = clock.querySelector('[role="arrow"]');
         type = clock.getAttribute('type');
         if (type === 'hours' && (hour == 0 || hour > 12) && data.mode === '24hr') {
@@ -547,7 +552,7 @@ gj.timepicker.methods = {
             header.querySelector('[role="hour"]').innerText = visualHour;
             header.querySelector('[role="minute"]').innerText = gj.core.pad(minute);
             if (data.mode === 'ampm') {
-                if (hour >= 12) {
+                if (mode == "pm") {
                     header.querySelector('[role="pm"]').classList.add('selected');
                     header.querySelector('[role="am"]').classList.remove('selected');
                 } else {
@@ -691,7 +696,7 @@ gj.timepicker.methods = {
     setAttributes: function (popup, data, date) {
         var hour = date.getHours();
         if (data.mode === 'ampm') {
-            popup.setAttribute('mode', hour > 12 ? 'pm' : 'am');
+            popup.setAttribute('mode', hour >= 12 ? 'pm' : 'am');
         }
         popup.setAttribute('hour', hour);
         popup.setAttribute('minute', date.getMinutes());


### PR DESCRIPTION
This patch is a proposed fix for issue https://github.com/atatanasov/gijgo/issues/666

It fixes the following when mode=ampm:
- 12:00 am is now shown in the text box as 12:00 am (not 0:00am)
- the AM/PM selector in the header now shows the correct initial value when the clock is first opened (previously it didn't show the correct value when the hour was 12)