### PR TITLE
Fix datepicker methods renderDecade and renderCentury 

### DIFF
--- a/src/datepicker/js/datepicker.base.js
+++ b/src/datepicker/js/datepicker.base.js
@@ -1174,7 +1174,7 @@ gj.datepicker.methods = {
     renderCentury: function (picker, calendar, data) {
         var year, century, i, d, decade,
             table = calendar.querySelector('[role="body"] table'),
-            tbody = $table.querySelector('tbody');
+            tbody = table.querySelector('tbody');
         
         table.querySelector('thead').style.display = 'none';
 

--- a/src/datepicker/js/datepicker.base.js
+++ b/src/datepicker/js/datepicker.base.js
@@ -1147,7 +1147,7 @@ gj.datepicker.methods = {
             table = calendar.querySelector('[role="body"] table'),
             tbody = table.querySelector('tbody');
         
-        table.querySelector('thead').display.style = 'none';
+        table.querySelector('thead').style.display = 'none';
 
         year = parseInt(calendar.getAttribute('year'), 10);
         decade = year - (year % 10);


### PR DESCRIPTION
Calling `renderDecade` (by clicking the datepicker header while viewing the year-overview) threw a TypeError. (See e.g. #665) 

After fixing this i uncovered and fixed a ReferenceError in `renderCentury`. 