### PR TITLE
update collapse selectors to only iterate expanded nodes

### DIFF
--- a/src/tree/js/tree.base.methods.js
+++ b/src/tree/js/tree.base.methods.js
@@ -177,7 +177,7 @@ gj.tree.methods = {
             $expander.attr('data-mode', 'close');
             $expander.empty().append(data.icons.expand);
             if (cascade) {
-                $children = $node.find('ul>li');
+                $children = $node.find('ul[style="display: block;"] > li:has(span[data-mode="open"])');
                 for (i = 0; i < $children.length; i++) {
                     gj.tree.methods.collapse($tree, $($children[i]), cascade);
                 }
@@ -195,7 +195,7 @@ gj.tree.methods = {
     },
 
     collapseAll: function ($tree) {
-        var i, $nodes = $tree.find('ul>li');
+        var i, $nodes = $tree.find('ul[style="display: block;"] > li:has(span[data-mode="open"])');
         for (i = 0; i < $nodes.length; i++) {
             gj.tree.methods.collapse($tree, $($nodes[i]), true);
         }


### PR DESCRIPTION
In trees with a large number of nodes, the collapse all method was _very_ slow (because it was iterating every single node). This should speed that up by only iterating open nodes.